### PR TITLE
fix aic3104 driver

### DIFF
--- a/esphome/components/aic3104/aic3104.cpp
+++ b/esphome/components/aic3104/aic3104.cpp
@@ -17,91 +17,7 @@ static const char *const TAG = "aic3104";
   }
 
 void AIC3104::setup() {
-  // Set register page to 0
-  ERROR_CHECK(this->write_byte(AIC3104_PAGE_CTRL, 0x00), "Set page 0 failed");
-  // Initiate SW reset (PLL is powered off as part of reset)
-  ERROR_CHECK(this->write_byte(AIC3104_SW_RST, 0x01), "Software reset failed");
-  
-  // *** Program clock settings ***
-  // Default is CODEC_CLKIN is from MCLK pin. Don't need to change this.
-  // MDAC*NDAC*FOSR*48Khz = mClk (24.576 MHz when the XMOS is expecting 48kHz audio)
-  // (See page 51 of https://www.ti.com/lit/ml/slaa557/slaa557.pdf)
-  // We do need MDAC*DOSR/32 >= the resource compute level for the processing block
-  // So here 2*128/32 = 8, which is adequate for basic processing
-
-  // Power up NDAC and set to 2
-  ERROR_CHECK(this->write_byte(AIC3104_NDAC, 0x82), "Set NDAC failed");
-  // Power up MDAC and set to 2
-  ERROR_CHECK(this->write_byte(AIC3104_MDAC, 0x82), "Set MDAC failed");
-  // Program DOSR = 128
-  ERROR_CHECK(this->write_byte(AIC3104_DOSR, 0x80), "Set DOSR failed");
-  // Set Audio Interface Config: I2S, 32 bits, DOUT always driving
-  ERROR_CHECK(this->write_byte(AIC3104_CODEC_IF, 0x30), "Set CODEC_IF failed");
-  // For I2S Firmware only, set SCLK/MFP3 pin as Audio Data In
-  ERROR_CHECK(this->write_byte(AIC3104_SCLK_MFP3, 0x02), "Set SCLK/MFP3 failed");
-  ERROR_CHECK(this->write_byte(AIC3104_AUDIO_IF_4, 0x01), "Set AUDIO_IF_4 failed");
-  ERROR_CHECK(this->write_byte(AIC3104_AUDIO_IF_5, 0x01), "Set AUDIO_IF_5 failed");
-  
-  // Note: AIC3104 doesn't have the advanced processing blocks of AIC3204
-  // Skip DAC signal processing block configuration as it uses simpler architecture
-
-  // *** Select Page 1 ***
-  ERROR_CHECK(this->write_byte(AIC3104_PAGE_CTRL, 0x01), "Set page 1 failed");
-  // Enable the internal AVDD_LDO:
-  ERROR_CHECK(this->write_byte(AIC3104_LDO_CTRL, 0x09), "Set LDO_CTRL failed");
-  // *** Program Analog Blocks ***
-  // Disable Internal Crude AVdd in presence of external AVdd supply or before powering up internal AVdd LDO
-  ERROR_CHECK(this->write_byte(AIC3104_PWR_CFG, 0x08), "Set PWR_CFG failed");
-  // Enable Master Analog Power Control
-  ERROR_CHECK(this->write_byte(AIC3104_LDO_CTRL, 0x01), "Set LDO_CTRL failed");
-  // Page 125: Common mode control register, set d6 to 1 to make the full chip common mode = 0.75 v
-  // We are using the internal AVdd regulator with a nominal output of 1.72 V (see LDO_CTRL_REGISTER on page 123)
-  ERROR_CHECK(this->write_byte(AIC3104_CM_CTRL, 0x40), "Set CM_CTRL failed");
-  // *** Set PowerTune Modes ***
-  // Set the Left & Right DAC PowerTune mode to PTM_P3/4. Use Class-AB driver.
-  ERROR_CHECK(this->write_byte(AIC3104_PLAY_CFG1, 0x00), "Set PLAY_CFG1 failed");
-  ERROR_CHECK(this->write_byte(AIC3104_PLAY_CFG2, 0x00), "Set PLAY_CFG2 failed");
-  // Set the REF charging time to 40ms
-  ERROR_CHECK(this->write_byte(AIC3104_REF_STARTUP, 0x01), "Set REF_STARTUP failed");
-  // HP soft stepping settings for optimal pop performance at power up
-  // Rpop used is 6k with N = 6 and soft step = 20usec. This should work with 47uF coupling
-  // capacitor. Can try N=5,6 or 7 time constants as well. Trade-off delay vs "pop" sound.
-  ERROR_CHECK(this->write_byte(AIC3104_HP_START, 0x25), "Set HP_START failed");
-  // Route Left DAC to HPL
-  ERROR_CHECK(this->write_byte(AIC3104_HPL_ROUTE, 0x08), "Set HPL_ROUTE failed");
-  // Route Right DAC to HPR
-  ERROR_CHECK(this->write_byte(AIC3104_HPR_ROUTE, 0x08), "Set HPR_ROUTE failed");
-  // Route Left DAC to LOL
-  ERROR_CHECK(this->write_byte(AIC3104_LOL_ROUTE, 0x08), "Set LOL_ROUTE failed");
-  // Route Right DAC to LOR
-  ERROR_CHECK(this->write_byte(AIC3104_LOR_ROUTE, 0x08), "Set LOR_ROUTE failed");
-
-  // Unmute HPL and set gain to -2dB 
-  ERROR_CHECK(this->write_byte(AIC3104_HPL_GAIN, 0x3e), "Set HPL_GAIN failed");
-  // Unmute HPR and set gain to -2dB 
-  ERROR_CHECK(this->write_byte(AIC3104_HPR_GAIN, 0x3e), "Set HPR_GAIN failed");
-  // Unmute LOL and set gain to 0dB
-  ERROR_CHECK(this->write_byte(AIC3104_LOL_DRV_GAIN, 0x00), "Set LOL_DRV_GAIN failed");
-  // Unmute LOR and set gain to 0dB
-  ERROR_CHECK(this->write_byte(AIC3104_LOR_DRV_GAIN, 0x00), "Set LOR_DRV_GAIN failed");
-
-  // Power up HPL and HPR, LOL and LOR drivers
-  ERROR_CHECK(this->write_byte(AIC3104_OP_PWR_CTRL, 0x3C), "Set OP_PWR_CTRL failed");
-
-  // Wait for 2.5 sec for soft stepping to take effect before attempting power-up
-  this->set_timeout(2500, [this]() {
-    // *** Power Up DAC ***
-    // Select Page 0
-    ERROR_CHECK(this->write_byte(AIC3104_PAGE_CTRL, 0x00), "Set PAGE_CTRL failed");
-    // Power up the Left and Right DAC Channels. Route Left data to Left DAC and Right data to Right DAC.
-    // DAC Vol control soft step 1 step per DAC word clock.
-    // Note: AIC3104 uses simpler configuration without advanced auto-mute features
-    ERROR_CHECK(this->write_byte(AIC3104_DAC_CH_SET1, 0xd4), "Set DAC_CH_SET1 failed");
-    // Set left and right DAC digital volume control
-    ERROR_CHECK(this->write_volume_(), "Set volume failed");
-    // Unmute left and right channels
-    ERROR_CHECK(this->write_mute_(), "Set mute failed");
-  });
+  // do nothing
 }
 
 void AIC3104::dump_config() {
@@ -138,7 +54,7 @@ float AIC3104::volume() { return this->volume_; }
 bool AIC3104::write_mute_() {
   // XVF3800/AIC3104 mute control - setting volume to maximum attenuation
   // Based on Seeed Studio approach
-  uint8_t mute_value = this->is_muted_ ? 0x48 : ((1.0f - this->volume_) * 0x48); // 0x48 = max attenuation/mute
+  uint8_t mute_value = this->is_muted_ ? 0x80 : ((1.0f - this->volume_) * 0x80); // 0x48 = max attenuation/mute
   
   if (!this->write_byte(AIC3104_PAGE_CTRL, 0x00) || 
       !this->write_byte(AIC3104_LEFT_DAC_VOLUME, mute_value) ||
@@ -162,10 +78,10 @@ bool AIC3104::write_volume_() {
     return false;
   }
   
-  // Map volume 0.0-1.0 to DAC range 0x48-0x00 (inverted)
-  // 0x00 = 0dB (loudest), 0x48 = -72dB (quietest)
-  uint8_t dac_val = (uint8_t)((1.0f - this->volume_) * 0x48);
-  dac_val = clamp<uint8_t>(dac_val, 0x00, 0x48);
+  // Map volume 0.0-1.0 to DAC range 0x80-0x00 (inverted)
+  // 0x00 = 0dB (loudest), 0x7F = -63.5dB (quietest), 0x80 = mute
+  uint8_t dac_val = (uint8_t)((1.0f - this->volume_) * 0x80);
+  dac_val = clamp<uint8_t>(dac_val, 0x00, 0x80);
   
   ESP_LOGD(TAG, "Writing DAC volume: 0x%.2x (%.1fdB attenuation) to registers 0x2B/0x2C", 
            dac_val, -(float)dac_val);

--- a/esphome/components/aic3104/aic3104.h
+++ b/esphome/components/aic3104/aic3104.h
@@ -11,62 +11,91 @@ namespace aic3104 {
 
 // TLV320AIC3104 Register Addresses
 // Page 0
-static const uint8_t AIC3104_PAGE_CTRL = 0x00;     // Register 0  - Page Control
-static const uint8_t AIC3104_SW_RST = 0x01;        // Register 1  - Software Reset
-static const uint8_t AIC3104_CLK_PLL1 = 0x04;      // Register 4  - Clock Setting Register 1, Multiplexers
-static const uint8_t AIC3104_CLK_PLL2 = 0x05;      // Register 5  - Clock Setting Register 2, P and R values
-static const uint8_t AIC3104_CLK_PLL3 = 0x06;      // Register 6  - Clock Setting Register 3, J values
-static const uint8_t AIC3104_NDAC = 0x0B;          // Register 11 - NDAC Divider Value
-static const uint8_t AIC3104_MDAC = 0x0C;          // Register 12 - MDAC Divider Value
-static const uint8_t AIC3104_DOSR = 0x0E;          // Register 14 - DOSR Divider Value (LS Byte)
-static const uint8_t AIC3104_NADC = 0x12;          // Register 18 - NADC Divider Value
-static const uint8_t AIC3104_MADC = 0x13;          // Register 19 - MADC Divider Value
-static const uint8_t AIC3104_AOSR = 0x14;          // Register 20 - AOSR Divider Value
-static const uint8_t AIC3104_CODEC_IF = 0x1B;      // Register 27 - CODEC Interface Control
-static const uint8_t AIC3104_AUDIO_IF_4 = 0x1F;    // Register 31 - Audio Interface Setting Register 4
-static const uint8_t AIC3104_AUDIO_IF_5 = 0x20;    // Register 32 - Audio Interface Setting Register 5
-static const uint8_t AIC3104_SCLK_MFP3 = 0x38;     // Register 56 - SCLK/MFP3 Function Control
-// Note: AIC3104 uses simpler processing blocks compared to AIC3204
-static const uint8_t AIC3104_DAC_CH_SET1 = 0x3F;   // Register 63 - DAC Channel Setup 1
-static const uint8_t AIC3104_DAC_CH_SET2 = 0x40;   // Register 64 - DAC Channel Setup 2
-static const uint8_t AIC3104_DACL_VOL_D = 0x41;    // Register 65 - DAC Left Digital Vol Control
-static const uint8_t AIC3104_DACR_VOL_D = 0x42;    // Register 66 - DAC Right Digital Vol Control
-// Seeed Studio example uses these alternative volume registers:
-static const uint8_t AIC3104_LEFT_DAC_VOLUME = 0x2B;   // Alternative DAC volume register used in XVF3800
-static const uint8_t AIC3104_RIGHT_DAC_VOLUME = 0x2C;  // Alternative DAC volume register used in XVF3800
-static const uint8_t AIC3104_ADC_CH_SET = 0x51;    // Register 81 - ADC Channel Setup
-static const uint8_t AIC3104_ADC_FGA_MUTE = 0x52;  // Register 82 - ADC Fine Gain Adjust/Mute
-
-// Page 1
-static const uint8_t AIC3104_PWR_CFG = 0x01;       // Register 1  - Power Config
-static const uint8_t AIC3104_LDO_CTRL = 0x02;      // Register 2  - LDO Control
-static const uint8_t AIC3104_PLAY_CFG1 = 0x03;     // Register 3  - Playback Config 1
-static const uint8_t AIC3104_PLAY_CFG2 = 0x04;     // Register 4  - Playback Config 2
-static const uint8_t AIC3104_OP_PWR_CTRL = 0x09;   // Register 9  - Output Driver Power Control
-static const uint8_t AIC3104_CM_CTRL = 0x0A;       // Register 10 - Common Mode Control
-static const uint8_t AIC3104_HPL_ROUTE = 0x0C;     // Register 12 - HPL Routing Select
-static const uint8_t AIC3104_HPR_ROUTE = 0x0D;     // Register 13 - HPR Routing Select
-static const uint8_t AIC3104_LOL_ROUTE = 0x0E;     // Register 14 - LOL Routing Selection
-static const uint8_t AIC3104_LOR_ROUTE = 0x0F;     // Register 15 - LOR Routing Selection
-static const uint8_t AIC3104_HPL_GAIN = 0x10;      // Register 16 - HPL Driver Gain
-static const uint8_t AIC3104_HPR_GAIN = 0x11;      // Register 17 - HPR Driver Gain
-static const uint8_t AIC3104_LOL_DRV_GAIN = 0x12;  // Register 18 - LOL Driver Gain Setting
-static const uint8_t AIC3104_LOR_DRV_GAIN = 0x13;  // Register 19 - LOR Driver Gain Setting
-// Seeed Studio example uses these output level registers:
-static const uint8_t AIC3104_HPLOUT_LEVEL = 0x33;      // HPLOUT Output Level Control (XVF3800 style)
-static const uint8_t AIC3104_HPROUT_LEVEL = 0x41;      // HPROUT Output Level Control (XVF3800 style)  
-static const uint8_t AIC3104_LEFT_LOP_LEVEL = 0x56;    // Left LOP Output Level Control (XVF3800 style)
-static const uint8_t AIC3104_RIGHT_LOP_LEVEL = 0x5D;   // Right LOP Output Level Control (XVF3800 style)
-static const uint8_t AIC3104_HP_START = 0x14;      // Register 20 - Headphone Driver Startup
-static const uint8_t AIC3104_LPGA_P_ROUTE = 0x34;  // Register 52 - Left PGA Positive Input Route
-static const uint8_t AIC3104_LPGA_N_ROUTE = 0x36;  // Register 54 - Left PGA Negative Input Route
-static const uint8_t AIC3104_RPGA_P_ROUTE = 0x37;  // Register 55 - Right PGA Positive Input Route
-static const uint8_t AIC3104_RPGA_N_ROUTE = 0x39;  // Register 57 - Right PGA Negative Input Route
-static const uint8_t AIC3104_LPGA_VOL = 0x3B;      // Register 59 - Left PGA Volume
-static const uint8_t AIC3104_RPGA_VOL = 0x3C;      // Register 60 - Right PGA Volume
-static const uint8_t AIC3104_ADC_PTM = 0x3D;       // Register 61 - ADC Power Tune Config
-static const uint8_t AIC3104_AN_IN_CHRG = 0x47;    // Register 71 - Analog Input Quick Charging Config
-static const uint8_t AIC3104_REF_STARTUP = 0x7B;   // Register 123 - Reference Power Up Config
+#define AIC3104_PAGE_CTRL               0x00 // Register 0 - Page Control
+#define AIC3104_SW_RST                  0x01 // Register 1 - Software Reset
+#define AIC3104_CODEC_SR_SEL            0x02 // Register 2: Codec Sample Rate Select Register
+#define AIC3104_PLL_Q_P                 0x03 // Register 3: PLL Programming Register A (Q and P value)
+#define AIC3104_PLL_J                   0x04 // Register 4: PLL Programming Register B (J value)
+#define AIC3104_PLL_D_MSB               0x05 // Register 5: PLL Programming Register C (D value MSB)
+#define AIC3104_PLL_D_LSB               0x06 // Register 6: PLL Programming Register D (D value LSB)
+#define AIC3104_CODEC_DATA_PATH         0x07 // Register 7: Codec Data-Path Setup Register
+#define AIC3104_ASD_IF_CTRL_A           0x08 // Register 8: Audio Serial Data Interface Control Register A
+#define AIC3104_ASD_IF_CTRL_B           0x09 // Register 9: Audio Serial Data Interface Control Register B
+#define AIC3104_ASD_IF_CTRL_C           0x0A // Register 10: Audio Serial Data Interface Control Register C
+#define AIC3104_OVRF_STATUS_PLL_R       0x0B // Register 11: Audio Codec Overflow Flag Register and PLL R value
+#define AIC3104_DIGITAL_FILTER          0x0C // Register 12: Audio Codec Digital Filter Control Register
+#define AIC3104_HEADSET_BUT_DET_A       0x0D // Register 13: Headset, Button Press Detection Register A
+#define AIC3104_HEADSET_BUT_DET_B       0x0E // Register 14: Headset, Button Press Detection Register B
+#define AIC3104_LEFT_ADC_PGA            0x0F // Register 15: Left-ADC PGA Gain Control Register
+#define AIC3104_RIGHT_ADC_PGA           0x10 // Register 16: Right-ADC PGA Gain Control Register
+#define AIC3104_MIC2LR_LADC             0x11 // Register 17: MIC2L/R to Left-ADC Control Register
+#define AIC3104_MIC2_LINE2_RADC         0X12 // Register 18: MIC2/LINE2 to Right-ADC Control Register
+#define AIC3104_MIC1LP_LINE1LP_LADC     0x13 // Register 19: MIC1LP/LINE1LP to Left-ADC Control Register
+#define AIC3104_MIC1RP_LINE1RP_LADC     0x15 // Register 21: MIC1RP/LINE1RP to Left-ADC Control Register
+#define AIC3104_MIC1RP_LINE1RP_RADC     0x16 // Register 22: MIC1RP/LINE1RP to Right-ADC Control Register
+#define AIC3104_MIC1LP_LINE1LP_RADC     0x18 // Register 24: MIC1LP/LINE1LP to Right-ADC Control Register
+#define AIC3104_MICBIAS_CTRL            0x19 // Register 25: MICBIAS Control Register
+#define AIC3104_LAGC_CTRL_A             0x1A // Register 26: Left-AGC Control Register A
+#define AIC3104_LAGC_CTRL_B             0x1B // Register 27: Left-AGC Control Register B
+#define AIC3104_LAGC_CTRL_C             0x1C // Register 28: Left-AGC Control Register C
+#define AIC3104_RAGC_CTRL_A             0x1D // Register 29: Right-AGC Control Register A
+#define AIC3104_RAGC_CTRL_B             0x1E // Register 30: Right-AGC Control Register B
+#define AIC3104_RAGC_CTRL_C             0x1F // Register 31: Right-AGC Control Register C
+#define AIC3104_LAGC_GAIN               0x20 // Register 32: Left-AGC Gain Register
+#define AIC3104_RAGC_GAIN               0x21 // Register 33: Right-AGC Gain Register
+#define AIC3104_LAGC_NOISE_GATE_DB      0x22 // Register 34: Left-AGC Noise Gate Debounce Register
+#define AIC3104_RAGC_NOISE_GATE_DB      0x23 // Register 35: Right-AGC Noise Gate Debounce Register
+#define AIC3104_ADC_FLAG                0x24 // Register 36: ADC Flag Register
+#define AIC3104_DAC_POWER_OUTPUT        0x25 // Register 37: DAC Power and Output Driver Control Register
+#define AIC3104_HP_OUTPUT_CTRL          0x26 // Register 38: High-Power Output Driver Control Register
+#define AIC3104_HP_OUTPUT_STAGE         0x28 // Register 40: High-Power Output Stage Control Register
+#define AIC3104_DAC_OUTPUT_SWITCH       0x29 // Register 41: DAC Output Switching Control Register
+#define AIC3104_OUTPUT_POP_REDUCE       0x2A // Register 42: Output Driver Pop Reduction Register
+#define AIC3104_LEFT_DAC_VOLUME         0x2B // Register 43: Left-DAC Digital Volume Control Register
+#define AIC3104_RIGHT_DAC_VOLUME        0x2C // Register 44: Right-DAC Digital Volume Control Register
+#define AIC3104_PGA_L_HPLOUT_VOLUME     0x2E // Register 46: PGA_L to HPLOUT Volume Control Register
+#define AIC3104_DAC_L1_HPLOUT_VOLUME    0x2F // Register 47: DAC_L1 to HPLOUT Volume Control Register
+#define AIC3104_PGA_R_HPLOUT_VOLUME     0x31 // Register 49: PGA_R to HPLOUT Volume Control Register
+#define AIC3104_DAC_R1_HPLOUT_VOLUME    0x32 // Register 50: DAC_R1 to HPLOUT Volume Control Register
+#define AIC3104_HPLOUT_LEVEL            0x33 // Register 51: HPLOUT Output Level Control Register
+#define AIC3104_PGA_L_HPLCOM_VOLUME     0x35 // Register 53: PGA_L to HPLCOM Volume Control Register
+#define AIC3104_DAC_L1_HPLCOM_VOLUME    0x36 // Register 54: DAC_L1 to HPLCOM Volume Control Register
+#define AIC3104_PGA_R_HPLCOM_VOLUME     0x38 // Register 56: PGA_R to HPLCOM Volume Control Register
+#define AIC3104_DAC_R1_HPLCOM_VOLUME    0x39 // Register 57: DAC_R1 to HPLCOM Volume Control Register
+#define AIC3104_HPLCOM_LEVEL            0x3A // Register 58: HPLCOM Output Level Control Register
+#define AIC3104_PGA_L_HPROUT_VOLUME     0x3C // Register 60: PGA_L to HPROUT Volume Control Register
+#define AIC3104_DAC_L1_HPROUT_VOLUME    0x3D // Register 61: DAC_L1 to HPROUT Volume Control Register
+#define AIC3104_PGA_R_HPROUT_VOLUME     0x3F // Register 63: PGA_R to HPROUT Volume Control Register
+#define AIC3104_DAC_R1_HPROUT_VOLUME    0x40 // Register 64: DAC_R1 to HPROUT Volume Control Register
+#define AIC3104_HPROUT_LEVEL            0x41 // Register 65: HPROUT Output Level Control Register
+#define AIC3104_PGA_L_HPRCOM_VOLUME     0x43 // Register 67: PGA_L to HPRCOM Volume Control Register
+#define AIC3104_DAC_L1_HPRCOM_VOLUME    0x44 // Register 68: DAC_L1 to HPRCOM Volume Control Register
+#define AIC3104_PGA_R_HPRCOM_VOLUME     0x46 // Register 70: PGA_R to HPRCOM Volume Control Register
+#define AIC3104_DAC_R1_HPRCOM_VOLUME    0x47 // Register 71: DAC_R1 to HPRCOM Volume Control Register
+#define AIC3104_HPRCOM_LEVEL            0x48 // Register 72: HPRCOM Output Level Control Register
+#define AIC3104_PGA_L_LEFT_LOP_VOLUME   0x51 // Register 81: PGA_L to LEFT_LOP/M Volume Control Register
+#define AIC3104_DAC_L1_LEFT_LOP_VOLUME  0x52 // Register 82: DAC_L1 to LEFT_LOP/M Volume Control Register
+#define AIC3104_PGA_R_LEFT_LOP_VOLUME   0x54 // Register 84: PGA_R to LEFT_LOP/M Volume Control Register
+#define AIC3104_DAC_R1_LEFT_LOP_VOLUME  0x55 // Register 85: DAC_R1 to LEFT_LOP/M Volume Control Register
+#define AIC3104_LEFT_LOP_LEVEL          0x56 // Register 86: LEFT_LOP/M Output Level Control Register
+#define AIC3104_PGA_L_RIGHT_LOP_VOLUME  0x58 // Register 88: PGA_L to RIGHT_LOP/M Volume Control Register
+#define AIC3104_DAC_L1_RIGHT_LOP_VOLUME 0x59 // Register 89: DAC_L1 to RIGHT_LOP/M Volume Control Register
+#define AIC3104_PGA_R_RIGHT_LOP_VOLUME  0x5B // Register 91: PGA_R to RIGHT_LOP/M Volume Control Register
+#define AIC3104_DAC_R1_RIGHT_LOP_VOLUME 0x5C // Register 92: DAC_R1 to RIGHT_LOP/M Volume Control Register
+#define AIC3104_RIGHT_LOP_LEVEL         0x5D // Register 93: RIGHT_LOP/M Output Level Control Register
+#define AIC3104_MODULE_POWER_STATUS     0x5E // Register 94: Module Power Status Register
+#define AIC3104_OUTPUT_SCD_STATUS       0x5F // Register 95: Output Driver Short-Circuit Detection Status Register
+#define AIC3104_STICKY_INT_FLAGS        0x60 // Register 96: Sticky Interrupt Flags Register
+#define AIC3104_REALTIME_INT_FLAGS      0x61 // Register 97: Real-Time Interrupt Flags Register
+#define AIC3104_CLOCK_REG               0x65 // Register 101: Clock Register
+#define AIC3104_CLOCK_GEN_CTRL          0x66 // Register 102: Clock Generation Control Register
+#define AIC3104_LAGC_NEW_ATTACK         0x67 // Register 103: Left-AGC New Programmable Attack Time Register
+#define AIC3104_LAGC_NEW_DECAY          0x68 // Register 104: Left-AGC New Programmable Decay Time Register
+#define AIC3104_RAGC_NEW_ATTACK         0x69 // Register 105: Right-AGC New Programmable Attack Time Register
+#define AIC3104_RAGC_NEW_DECAY          0x6A // Register 106: Right-AGC New Programmable Decay Time Register
+#define AIC3104_NEW_ADC_PATH            0x6B // Register 107: New Programmable ADC Digital Path and I2C Bus Condition Register
+#define AIC3104_PASSIVE_BYPASS          0x6C // Register 108: Passive Analog Signal Bypass Selection During Power Down Register
+#define AIC3104_DAC_QUIESCENT_CUR       0x6D // Register 109: DAC Quiescent Current Adjustment Register
 
 class AIC3104 : public audio_dac::AudioDac, public Component, public i2c::I2CDevice {
  public:


### PR DESCRIPTION
1. Remove the setup() code, as aic3104 is already set by XMOS
2. Update the register settings of volume control